### PR TITLE
migration fixes unique constraints and missing app columns

### DIFF
--- a/configuration/doctrine/Application.GitHubApplication.orm.yml
+++ b/configuration/doctrine/Application.GitHubApplication.orm.yml
@@ -4,10 +4,10 @@
     fields:
 
         owner:
-            column: 'github_owner'
+            column: 'owner'
             type: 'string'
             length: 100
         repository:
-            column: 'github_repository'
+            column: 'repository'
             type: 'string'
             length: 100

--- a/migrations/20170130020000_initial_schema_for3.php
+++ b/migrations/20170130020000_initial_schema_for3.php
@@ -60,9 +60,11 @@ class InitialSchemaFor3 extends PhinxMigration
 
         // applications
         $this->createUUIDTable('applications')
-            ->addColumn('identifier',      'string',  ['limit' => 30])
-            ->addColumn('name',            'string',  ['limit' => 100])
-            ->addColumn('organization_id', 'uuid',    [])
+            ->addColumn('identifier',        'string',  ['limit' => 30])
+            ->addColumn('name',              'string',  ['limit' => 100])
+            ->addColumn('organization_id',   'uuid',    [])
+            ->addColumn('github_owner',      'string',  ['limit' => 100])
+            ->addColumn('github_repository', 'string',  ['limit' => 100])
             ->update();
 
         // credentials

--- a/migrations/20170130030000_initial_indexes_for3.php
+++ b/migrations/20170130030000_initial_indexes_for3.php
@@ -27,6 +27,15 @@ class InitialIndexesFor3 extends PhinxMigration
      */
     public function change()
     {
+        // Handle unique columns
+        foreach ($this->uniqueColumns() as $table => $columns) {
+            $table = $this->table($table);
+
+            $table = $table->addIndex($columns, ['unique' => true]);
+
+            $table->update();
+        }
+
         // Handle searchable columns
         foreach ($this->searchableColumns() as $table => $columns) {
             $table = $this->table($table);
@@ -48,6 +57,16 @@ class InitialIndexesFor3 extends PhinxMigration
                     ->update();
             }
         }
+    }
+
+    protected function uniqueColumns()
+    {
+        return [
+            'users' =>            ['username'],
+            'organizations' =>    ['identifier'],
+            'environments' =>     ['name'],
+            'applications' =>     ['identifier'],
+        ];
     }
 
     protected function searchableColumns()


### PR DESCRIPTION
### Change notes
- `GithubApplication` entity definitions dropped the `github_` prefix as doctrine already prefixes when embedded this lead to a column named `gitHub_github_owner` 
- added `github_owner` and `github_repository` column names in `applications` table
- added unique constraints from hal-platform/hal#48 

### Notes
- Migrations will need to be reverted and rerun after this is merged.

fixes hal-platform/hal#48