### PR TITLE
changed configuration to config

### DIFF
--- a/bin/doctrine
+++ b/bin/doctrine
@@ -22,9 +22,9 @@ error_reporting(E_ALL | E_STRICT);
 
 $di = new ContainerBuilder;
 $builder = new YamlFileLoader($di, new FileLocator($root));
-$builder->load('config/hal-core.yml');
+$builder->load('config/config.yaml');
 
-$di->compile();
+$di->compile(true);
 
 $helperSet = ConsoleRunner::createHelperSet($di->get('doctrine.em'));
 ConsoleRunner::run($helperSet, []);

--- a/bin/doctrine
+++ b/bin/doctrine
@@ -22,7 +22,7 @@ error_reporting(E_ALL | E_STRICT);
 
 $di = new ContainerBuilder;
 $builder = new YamlFileLoader($di, new FileLocator($root));
-$builder->load('configuration/hal-core.yml');
+$builder->load('config/hal-core.yml');
 
 $di->compile();
 


### PR DESCRIPTION
- Missed -- `configuration` moved to `config`
- Env vars are not resolved unless you dump the container or pass `true` to the compile function.