### PR TITLE
target credentail null on  delete

### DIFF
--- a/migrations/20170130030000_initial_indexes.php
+++ b/migrations/20170130030000_initial_indexes.php
@@ -52,8 +52,15 @@ class InitialIndexes extends PhinxMigration
             list($parentTable, $relationColumn) = explode('/', $parent);
 
             foreach ($children as $childTable) {
+                $options = [];
+                if ($childTable === 'targets' && $relationColumn == 'credential_id') {
+                    $options = [
+                        'delete' => 'SET_NULL',
+                        'update'=> 'CASCADE'
+                    ];
+                }
                 $this->table($childTable)
-                    ->addForeignKey($relationColumn, $parentTable, 'id')
+                    ->addForeignKey($relationColumn, $parentTable, 'id', $options)
                     ->update();
             }
         }


### PR DESCRIPTION
Sets null for target credentials when credential deleted.

part of hal-platform/hal#59