### PR TITLE
Remove PhinxMigration from Coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -28,6 +28,9 @@
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
             <directory>src</directory>
+            <exclude>
+                <file>src/Database/PhinxMigration.php</file>
+            </exclude>
         </whitelist>
     </filter>
 


### PR DESCRIPTION
This removes `PhinxMigration` from code coverage checks so phpunit still passes when checking code coverage.