### PR TITLE
Allow GHE VCS URL to have a trailing slash

### DIFF
--- a/src/VersionControl/VCS/GitHubEnterpriseVCS.php
+++ b/src/VersionControl/VCS/GitHubEnterpriseVCS.php
@@ -131,7 +131,7 @@ class GitHubEnterpriseVCS
             return null;
         }
 
-        $baseURL = $baseURL . '/api/v3/';
+        $baseURL = rtrim($baseURL, '/') . '/api/v3/';
 
         $options = $this->defaultGuzzleOptions + [
             'base_uri' => $baseURL,


### PR DESCRIPTION
This change removes any extra trailing slashes in the provided GitHub Enterprise URL before appending the api path, decreasing the chances of receiving 404 errors.