### PR TITLE
fixing broken mysql migrations

### DIFF
--- a/migrations/20170130020000_initial_schema.php
+++ b/migrations/20170130020000_initial_schema.php
@@ -231,7 +231,7 @@ class InitialSchema extends PhinxMigration
             ->addColumn('event_duration', 'integer',    [])
             ->addColumn('event_order',    'integer',    [])
             ->addColumn('message',        'string',     ['limit' => 200])
-            ->addColumn('parameters',     'binary',     $this->blobOptions('16mb'))
+            ->addColumn('parameters',     'blob',       $this->blobOptions('16mb'))
 
             ->addColumn('job_id',         'uuid',       ['null' => false])
             ->update();

--- a/src/Database/PhinxMigration.php
+++ b/src/Database/PhinxMigration.php
@@ -7,6 +7,7 @@
 
 namespace Hal\Core\Database;
 
+use Phinx\Db\Adapter\AdapterWrapper;
 use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Db\Table;
 use Phinx\Migration\AbstractMigration;
@@ -75,7 +76,13 @@ class PhinxMigration extends AbstractMigration
     {
         $limit = (strtolower($size) === '16mb') ? MysqlAdapter::BLOB_MEDIUM : MysqlAdapter::BLOB_REGULAR;
 
-        return $this->getAdapter() instanceof MysqlAdapter ? ['limit' => $limit] : [];
+        $adapter = $this->getAdapter();
+
+        if ($adapter instanceof AdapterWrapper) {
+            $adapter = $adapter->getAdapter();
+        }
+
+        return $adapter instanceof MysqlAdapter ? ['limit' => $limit] : [];
     }
 
     /**
@@ -91,6 +98,12 @@ class PhinxMigration extends AbstractMigration
     {
         $limit = (strtolower($size) === '16mb') ? MysqlAdapter::TEXT_MEDIUM : MysqlAdapter::TEXT_REGULAR;
 
-        return $this->getAdapter() instanceof MysqlAdapter ? ['limit' => $limit] : [];
+        $adapter = $this->getAdapter();
+
+        if ($adapter instanceof AdapterWrapper) {
+            $adapter = $adapter->getAdapter();
+        }
+
+        return $adapter instanceof MysqlAdapter ? ['limit' => $limit] : [];
     }
 }


### PR DESCRIPTION
Fixed two issues when trying to use migrations on mysql

### Issues
1. The `binary` and `blob` types are different in MySQL (for postgres phinx alias both to the bytea type)
2. The adapter in the migration is sometimes a `AdapterWrapper` around the actual adapter.

### Fixes
1. Set column type to `blob` instead of `binary`
2. Get adapter and check if is an `AdapterWrapper` if it is get the adapter it wraps
