### PR TITLE
Add isOAuth field to IDP

### DIFF
--- a/config/doctrine/System/UserIdentityProvider.orm.yaml
+++ b/config/doctrine/System/UserIdentityProvider.orm.yaml
@@ -23,6 +23,11 @@
             length: 50
             options: { default: 'internal' } # See IdentityProviderEnum for list of options
 
+        isOAuth:
+            column: 'is_oauth'
+            type: 'boolean'
+            options: { default: false }
+
         parameters:
             column: 'parameters'
             type: 'json_array'

--- a/migrations/20170130020000_initial_schema.php
+++ b/migrations/20170130020000_initial_schema.php
@@ -90,6 +90,7 @@ class InitialSchema extends PhinxMigration
         $this->createUUIDTable('system_identity_providers')
             ->addColumn('created',       'datetime', [])
             ->addColumn('name',          'string',   ['limit' => 100])
+            ->addColumn('is_oauth',      'boolean',  ['default' => false])
             ->addColumn('provider_type', 'string',   $this->enumOptions('internal'))
             ->addColumn('parameters',    'json',     [])
             ->update();

--- a/src/Entity/System/UserIdentityProvider.php
+++ b/src/Entity/System/UserIdentityProvider.php
@@ -29,6 +29,11 @@ class UserIdentityProvider implements JsonSerializable
     protected $type;
 
     /**
+     * @var bool
+     */
+    protected $isOAuth;
+
+    /**
      * @param string $id
      * @param TimePoint|null $created
      */
@@ -36,6 +41,8 @@ class UserIdentityProvider implements JsonSerializable
     {
         $this->initializeEntity($id, $created);
         $this->initializeParameters();
+
+        $this->isOAuth = false;
 
         $this->name = '';
         $this->type = IdentityProviderEnum::defaultOption();
@@ -58,6 +65,14 @@ class UserIdentityProvider implements JsonSerializable
     }
 
     /**
+     * @return bool
+     */
+    public function isOAuth(): bool
+    {
+        return $this->isOAuth;
+    }
+
+    /**
      * @param string $name
      *
      * @return self
@@ -76,6 +91,17 @@ class UserIdentityProvider implements JsonSerializable
     public function withType(string $type): self
     {
         $this->type = IdentityProviderEnum::ensureValid($type);
+        return $this;
+    }
+
+    /**
+     * @param bool $isOAuth
+     *
+     * @return self
+     */
+    public function withIsOAuth(bool $isOAuth): self
+    {
+        $this->isOAuth = $isOAuth;
         return $this;
     }
 


### PR DESCRIPTION
This adds an `isOAuth` field to Identity Providers so it is easier to determine authentication flow between different providers