### PR TITLE
generate proxies without connecting to cache

### DIFF
--- a/config/hal-core.yaml
+++ b/config/hal-core.yaml
@@ -62,9 +62,18 @@ services:
         factory: ['Doctrine\ORM\EntityManager', 'create']
         arguments:
             - '%doctrine.proxy.connection%'
-            - '@doctrine.config'
+            - '@doctrine.em.proxy.config'
             - '@doctrine.em.event_manager'
         configurator: ['@doctrine.em.configurator', 'configure']
+
+    doctrine.em.proxy.config:
+        class: 'Doctrine\ORM\Configuration'
+        factory: ['Doctrine\ORM\Tools\Setup', 'createConfiguration']
+        arguments:
+            - '%doctrine.config.dev_mode%'
+            - '%doctrine.path.proxy%'
+        calls:
+            - ['setMetadataDriverImpl', ['@doctrine.config.driver']]
 
     ############################################################################
     # DOCTRINE EM


### PR DESCRIPTION
# Changes
1. Added a doctrine configuration to be used for proxy generation
    - This is needed because otherwise if we set `HAL_ORM_CACHE=redis` generating the proxy entities will try and connect to the redis cache during build.